### PR TITLE
Point-independent code to avoid static linking issues

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,6 +13,9 @@ set -x -e
 INCLUDE_PATH="${PREFIX}/include"
 LIBRARY_PATH="${PREFIX}/lib"
 
+# Always build PIC code for enable static linking into other shared libraries
+CXXFLAGS="${CXXFLAGS} -fPIC"
+
 if [ "$(uname)" == "Darwin" ]; then
     MACOSX_VERSION_MIN=10.7
     CXXFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   md5: 6095876341956f65f9d35939ccea1a9f
 
 build:
-  number: 0
+  number: 1
   features:
     - vc9               # [win and py27]
     - vc10              # [win and py34]


### PR DESCRIPTION
The point independent code means that the boost static libraries can be properly statically linked while creating other shared libraries. This makes so that users of those shared libraries do not need to install the boost dynamic libraries on their system. 