### PR TITLE
Statically-link libstdc++ for portability on older Linuxes

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -45,7 +45,10 @@ fi
 
 if [ "$(uname)" == "Linux" ]; then
     CXXFLAGS="${CXXFLAGS} -std=c++11"
-    LINKFLAGS="${LINKFLAGS} -std=c++11 -L${LIBRARY_PATH}"
+
+    # static link libstdc++ so that the built libraries can be linked in
+    # environments with other gcc toolchains
+    LINKFLAGS="${LINKFLAGS} -static-libstdc++ -std=c++11 -L${LIBRARY_PATH}"
 
     ./bootstrap.sh \
         --prefix="${PREFIX}" \


### PR DESCRIPTION
Here is what I see on the current conda-forge boost build:

```shell
$ ldd libboost_system.so
	linux-vdso.so.1 =>  (0x00007ffc03fb2000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007feaa45ec000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007feaa42e8000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007feaa3fe1000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007feaa3dcb000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007feaa3bad000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007feaa37e7000)
	/lib64/ld-linux-x86-64.so.2 (0x0000561ecf845000)
```

This is fine if the libstdc++ in the conda-forge build and the dynamic library on the host system are ABI compatible (for example, on my system with gcc 4.8 standard, this is no problem). If you deploy on an older Linux, for example: CentOS 6 (which uses gcc 4.4.x), you may well run into ABI conflicts. 

Rather than state vague FUD it would be a good idea to come up with a demonstration of a segfault induced by ABI conflict. If anyone has the time to do this before I do it would be much appreciated. @njsmith from your work on manylinux can you comment? Thanks