### PR TITLE
Fix stderr capture

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,6 +9,7 @@
 # http://stackoverflow.com/questions/20108407/how-do-i-compile-boost-for-os-x-64b-platforms-with-stdlibc
 
 set -x -e
+set -o pipefail
 
 LIBRARY_PATH="${PREFIX}/lib"
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,7 +28,7 @@ LINKFLAGS="${LINKFLAGS} -L${LIBRARY_PATH}"
     --with-icu="${PREFIX}" \
     --with-python="${PYTHON}" \
     --with-python-root="${PREFIX} : ${PREFIX}/include/python${PY_VER}m ${PREFIX}/include/python${PY_VER}" \
-    | tee bootstrap.log 2>&1
+    2>&1 | tee bootstrap.log
 
 ./b2 -q \
     variant=release \
@@ -45,5 +45,4 @@ LINKFLAGS="${LINKFLAGS} -L${LIBRARY_PATH}"
     --layout=system \
     --with-python \
     -j"${CPU_COUNT}" \
-    install | tee b2.log 2>&1
-
+    install 2>&1 | tee b2.log

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,8 @@ package:
 
 source:
   fn:  {{ filename }}
-  url: http://sourceforge.net/projects/boost/files/boost/{{ version }}/{{ filename }}
+  #url: http://sourceforge.net/projects/boost/files/boost/{{ version }}/{{ filename }}
+  url: https://github.com/conda-forge/boost-feedstock/releases/download/sources/{{ filename }}
   sha256: beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0
   patches:
     - boost_python_pr110.patch


### PR DESCRIPTION
- redirect stderr from the build commands, not the one from tee.
- let the build fail when build command `cmd` in `cmd | tee` fails.