### PR TITLE
Patch BOOST_LIB_NAME for better Python 3 support

### DIFF
--- a/recipe/PR_135.diff
+++ b/recipe/PR_135.diff
@@ -1,0 +1,17 @@
+diff --git include/boost/python/detail/config.hpp include/boost/python/detail/config.hpp
+index c92ecb32b..3e4b7c9e5 100644
+--- include/boost/python/detail/config.hpp
++++ include/boost/python/detail/config.hpp
+@@ -105,7 +105,11 @@
+ // Set the name of our library, this will get undef'ed by auto_link.hpp
+ // once it's done with it:
+ //
+-#define BOOST_LIB_NAME boost_python
++#if PY_MAJOR_VERSION == 2
++#  define BOOST_LIB_NAME boost_python
++#elif PY_MAJOR_VERSION == 3
++#  define BOOST_LIB_NAME boost_python3
++#endif
+ //
+ // If we're importing code from a dll, then tell auto_link.hpp about it:
+ //

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - PR_135.diff
 
 build:
-  number: 1
+  number: 2
   features:
     - vc9               # [win and py27]
     - vc14              # [win and py>=35]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,12 @@ source:
   fn:  {{ filename }}
   url: https://dl.bintray.com/boostorg/release/{{ version }}/source/{{ filename }}
   sha256: 7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
+  patches:
+    # Applies a patch to correct `BOOST_LIB_NAME` on Python 3.
+    #
+    # xref: https://github.com/boostorg/python/pull/135
+    #
+    - PR_135.diff
 
 build:
   number: 1


### PR DESCRIPTION
Applies the patch from PR ( https://github.com/boostorg/python/pull/135 ) to correct an issue where Boost incorrectly links against `boost_python` libraries on Python 3 instead of `boost_python3` libraries. More info can be found in this related issue ( https://github.com/boostorg/python/issues/127 ).