### PR TITLE
Add 1.78 to migrations (as it is replacing 1.74)

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,7 @@
 bot:
   abi_migration_branches:
   - v1.74.x
+  - v1.78.x
 build_platform:
   linux_aarch64: linux_64
   osx_arm64: osx_64


### PR DESCRIPTION
There is an active [Boost migration to 1.78]( https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/71f47d193db51be75c56c8deccd29e77a4bf6603/recipe/migrations/boost1780.yaml ), which other migrations (like Python 3.11) need to work with. Have added this branch based on the last state of 1.78 in this feedstock (as `main` is on 1.80). Should ensure we start getting migration PRs there.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
