### PR TITLE
Inline `filename` in `url`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,11 @@
 {% set version = "1.80.0" %}
-{% set filename = "boost_%s.tar.bz2" % version.replace(".", "_") %}
 
 package:
   name: boost
   version: {{ version }}
 
 source:
-  fn: {{ filename }}
-  url: https://boostorg.jfrog.io/artifactory/main/release/{{ version }}/source/{{ filename }}
+  url: https://boostorg.jfrog.io/artifactory/main/release/{{ version }}/source/boost_{{ version|replace(".", "_") }}.tar.bz2
   sha256: 1e19565d82e43bc59209a168f5ac899d3ba471d55c7610c677d4ccf2c9c500c0
   patches:
     - 5eff1ecc8413b0dc93a1ab047d7fed751e6cb40e.patch


### PR DESCRIPTION
The `source/fn` entry is unneeded and can be dropped. Once dropped, the `url` can just inline `filename` to simplify the recipe. This will make things a bit easier on the version update bot and align with `boost-cpp`, which is making the same change ( https://github.com/conda-forge/boost-cpp-feedstock/pull/133 ).

xref: https://github.com/regro/cf-scripts/issues/1588

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
