### PR TITLE
backport patch for removed-in-C++17 std::{binary,unary}_function (yet again)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,11 @@ source:
   patches:
     # ensure our compiler flags get used during bootstrapping 
     - patches/0001-Add-default-value-for-cxx-and-cxxflags-options-for-t.patch
+    # backport https://github.com/boostorg/functional/commit/6a573e4b8333ee63ee62ce95558c3667348db233
+    - patches/0001-Define-unary_function-and-binary_function-unconditio.patch
 
 build:
-  number: 5
+  number: 6
 
 requirements:
   build:

--- a/recipe/patches/0001-Define-unary_function-and-binary_function-unconditio.patch
+++ b/recipe/patches/0001-Define-unary_function-and-binary_function-unconditio.patch
@@ -1,0 +1,34 @@
+From b9fe808ff49ee379c785542a1821c7a9be9bd3fa Mon Sep 17 00:00:00 2001
+From: Glen Fernandes <glen.fernandes@gmail.com>
+Date: Mon, 17 Apr 2023 06:59:02 -0400
+Subject: [PATCH] Define unary_function and binary_function unconditionally
+
+---
+ include/boost/functional.hpp | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/include/boost/functional.hpp b/include/boost/functional.hpp
+index 6443078..6c63146 100644
+--- a/include/boost/functional.hpp
++++ b/include/boost/functional.hpp
+@@ -21,7 +21,6 @@ namespace boost
+     namespace functional
+     {
+         namespace detail {
+-#if defined(_HAS_AUTO_PTR_ETC) && !_HAS_AUTO_PTR_ETC
+             // std::unary_function and std::binary_function were both removed
+             // in C++17.
+ 
+@@ -39,12 +38,6 @@ namespace boost
+                 typedef Arg2 second_argument_type;
+                 typedef Result result_type;
+             };
+-#else
+-            // Use the standard objects when we have them.
+-
+-            using std::unary_function;
+-            using std::binary_function;
+-#endif
+         }
+     }
+ 


### PR DESCRIPTION
Seems we get to relive https://github.com/conda-forge/boost-cpp-feedstock/issues/134 & https://github.com/conda-forge/boost-cpp-feedstock/pull/135, only slightly differently.

Still getting failures in https://github.com/conda-forge/graph-tool-feedstock/pull/114 of the kind:
```
In file included from ./src/graph/histogram.hh:26:
In file included from $PREFIX/include/boost/multi_array.hpp:34:
In file included from $PREFIX/include/boost/multi_array/multi_array_ref.hpp:32:
$PREFIX/include/boost/functional.hpp:45:24: error: no member named 'unary_function' in namespace 'std'; did you mean '__unary_function'?
            using std::unary_function;
                  ~~~~~^
```

That's because apparently, we're not automatically picking up `_HAS_AUTO_PTR_ETC`, which is the only [guard](https://github.com/boostorg/functional/blob/boost-1.82.0/include/boost/functional.hpp#L24) from using the deprecated functions as of boost 1.82.

This got fixed (presumably the last time) in https://github.com/boostorg/functional/commit/6a573e4b8333ee63ee62ce95558c3667348db233, so backport that patch.