### PR TITLE
remove libboost run-export from libboost-python-devel

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -2,8 +2,6 @@ NP_DUMMY_VER:
 - '1.21'
 PY_DUMMY_VER:
 - '3.10'
-boost:
-- 1.78.0
 bzip2:
 - '1'
 cdt_name:
@@ -28,8 +26,6 @@ numpy:
 - '1.22'
 - '1.22'
 pin_run_as_build:
-  boost:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -4,8 +4,6 @@ NP_DUMMY_VER:
 - '1.21'
 PY_DUMMY_VER:
 - '3.10'
-boost:
-- 1.78.0
 bzip2:
 - '1'
 cdt_arch:
@@ -32,8 +30,6 @@ numpy:
 - '1.22'
 - '1.22'
 pin_run_as_build:
-  boost:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -2,8 +2,6 @@ NP_DUMMY_VER:
 - '1.21'
 PY_DUMMY_VER:
 - '3.10'
-boost:
-- 1.78.0
 bzip2:
 - '1'
 cdt_name:
@@ -28,8 +26,6 @@ numpy:
 - '1.22'
 - '1.22'
 pin_run_as_build:
-  boost:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -4,8 +4,6 @@ NP_DUMMY_VER:
 - '1.21'
 PY_DUMMY_VER:
 - '3.10'
-boost:
-- 1.78.0
 bzip2:
 - '1'
 channel_sources:
@@ -28,8 +26,6 @@ numpy:
 - '1.22'
 - '1.22'
 pin_run_as_build:
-  boost:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -4,8 +4,6 @@ NP_DUMMY_VER:
 - '1.21'
 PY_DUMMY_VER:
 - '3.10'
-boost:
-- 1.78.0
 bzip2:
 - '1'
 channel_sources:
@@ -27,8 +25,6 @@ numpy:
 - '1.22'
 - '1.22'
 pin_run_as_build:
-  boost:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -2,8 +2,6 @@ NP_DUMMY_VER:
 - '1.21'
 PY_DUMMY_VER:
 - '3.10'
-boost:
-- 1.78.0
 bzip2:
 - '1'
 channel_sources:
@@ -22,8 +20,6 @@ numpy:
 - '1.22'
 - '1.22'
 pin_run_as_build:
-  boost:
-    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,24 @@
-*.pyc
+# User content belongs under recipe/.
+# Feedstock configuration goes in `conda-forge.yml`
+# Everything else is managed by the conda-smithy rerender process.
+# Please do not modify
 
-build_artifacts
+# Ignore all files and folders in root
+*
+!/conda-forge.yml
+
+# Don't ignore any files/folders if the parent folder is 'un-ignored'
+# This also avoids warnings when adding an already-checked file with an ignored parent.
+!/**/
+# Don't ignore any files/folders recursively in the following folders
+!/recipe/**
+!/.ci_support/**
+
+# Since we ignore files/folders recursively, any folders inside
+# build_artifacts gets ignored which trips some build systems.
+# To avoid that we 'un-ignore' all files/folders recursively
+# and only ignore the root build_artifacts folder.
+!/build_artifacts/**
+/build_artifacts
+
+*.pyc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -57,12 +57,6 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
   cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
 fi
 
-if [[ "${sha:-}" == "" ]]; then
-  pushd ${FEEDSTOCK_ROOT}
-  sha=$(git rev-parse HEAD)
-  popd
-fi
-
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,9 +34,9 @@ CONDARC
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4 "conda-build<3.28"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4 "conda-build<3.28"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -21,6 +21,12 @@ if [ -z ${FEEDSTOCK_NAME} ]; then
     export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd "${FEEDSTOCK_ROOT}"
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,9 +26,9 @@ export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4 "conda-build<3.28"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4 "conda-build<3.28"
 
 
 

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -24,7 +24,7 @@ set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-mamba.exe install "python=3.10" pip mamba conda-build boa conda-forge-ci-setup=4 -c conda-forge --strict-channel-priority --yes
+mamba.exe install "python=3.10" pip mamba conda-build boa conda-forge-ci-setup=4 "conda-build<3.28" -c conda-forge --strict-channel-priority --yes
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Set basic configuration

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -18,3 +18,7 @@ provider:
   linux_ppc64le: default
   win: azure
 test_on_native_only: true
+remote_ci_setup:
+  - conda-forge-ci-setup=4
+  # breakage due to (most likely) https://github.com/conda/conda-build/issues/5179
+  - conda-build<3.28

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - patches/0001-Add-default-value-for-cxx-and-cxxflags-options-for-t.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -273,8 +273,6 @@ outputs:
       run_exports:
         # run-export the output without the headers
         - {{ pin_subpackage("libboost-python", max_pin="x.x") }}
-        # output may also depend on boost libs
-        - {{ pin_subpackage("libboost", max_pin="x.x") }}
     requirements:
       # dummy build env to avoid EnvironmentLocationNotFound on win
       build:                # [win]


### PR DESCRIPTION
In preparation for the 1.84 migration, which fixes this aspect of the 1.82 migration (c.f. #176)

Closes #191