### PR TITLE
impose windows runtime constraint

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -112,7 +112,7 @@ outputs:
         # avoid co-installation with old naming of package
         - boost-cpp <0.0a0
         # see https://www.boost.org/users/history/version_1_87_x.html
-        - __win >=10        # [win]
+        - __win ==0|>=10        # [win]
     test:
       commands:
         # absence of headers

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
     - patches/0001-Add-default-value-for-cxx-and-cxxflags-options-for-t.patch
 
 build:
-  number: 1
+  number: 2
   script_env:
     - PY_DUMMY_VER={{ PY_DUMMY_VER }}
     - NP_DUMMY_VER={{ NP_DUMMY_VER }}
@@ -111,6 +111,8 @@ outputs:
       run_constrained:
         # avoid co-installation with old naming of package
         - boost-cpp <0.0a0
+        # see https://www.boost.org/users/history/version_1_87_x.html
+        - __win >=10        # [win]
     test:
       commands:
         # absence of headers


### PR DESCRIPTION
This is a follow-up to #221, which was merged before we had a solution to https://github.com/conda-forge/conda-forge.github.io/issues/2404. Trigger for this is that boost 1.87 dropped support for windows<10 (c.f. [release notes](https://www.boost.org/users/history/version_1_87_x.html)): 
> [Filesystem](https://www.boost.org/libs/filesystem/):
> As was announced in 1.84.0, Windows versions prior to 10 are no longer supported.

In the meantime, all major installers populate `__win` correctly since ([details](https://github.com/conda-forge/conda-forge.github.io/issues/2404#issuecomment-2727155833)):

* conda v25.1.0 (released 2025-01-17)
* mamba v2.0.0 (released 2024-09-25)
* pixi v0.41.0 (released 2025-02-05)

Given that boost 1.87 is not in wide-spread use in conda-forge, I think it's OK to impose this constraint, despite the relatively recent versions required to handle it. For affected windows users (on win<10 _and_ older installers), it's still better to get an unresolvable constraint rather than a broken package.