### PR TITLE
[v1.88.x] Add patch for msmpi missing MPI_CXX_BOOL

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-13
+    vmImage: macOS-15
   strategy:
     matrix:
       osx_64_:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,11 @@ source:
   patches:
     # ensure our compiler flags get used during bootstrapping
     - patches/0001-Add-default-value-for-cxx-and-cxxflags-options-for-t.patch
+    # fix missing MPI_CXX_BOOL symbol in msmpi
+    - patches/0002-Fix-MSMPI-missing-MPI_CXX_BOOL.patch
 
 build:
-  number: 2
+  number: 3
   script_env:
     - PY_DUMMY_VER={{ PY_DUMMY_VER }}
     - NP_DUMMY_VER={{ NP_DUMMY_VER }}

--- a/recipe/patches/0002-Fix-MSMPI-missing-MPI_CXX_BOOL.patch
+++ b/recipe/patches/0002-Fix-MSMPI-missing-MPI_CXX_BOOL.patch
@@ -1,0 +1,30 @@
+From 58e417214ef842047cd1ec9df602c5fc6241f832 Mon Sep 17 00:00:00 2001
+From: Samuel Debionne <samuel.debionne@esrf.fr>
+Date: Thu, 17 Apr 2025 17:55:55 +0200
+Subject: [PATCH] Fix MSMPI missing MPI_CXX_BOOL
+
+---
+ include/boost/mpi/datatype.hpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/include/boost/mpi/datatype.hpp b/include/boost/mpi/datatype.hpp
+index ef8aa2e..b098e20 100644
+--- a/boost/mpi/datatype.hpp
++++ b/boost/mpi/datatype.hpp
+@@ -213,8 +213,13 @@ BOOST_MPI_DATATYPE(packed, MPI_PACKED, builtin);
+ BOOST_MPI_DATATYPE(char, MPI_CHAR, builtin);
+ 
+ /// INTERNAL ONLY
++#if !defined(MSMPI_VER)
+ /// We need to pick a boolean type, MPI_CXX_BOOL seems appropriate
+ BOOST_MPI_DATATYPE(bool, MPI_CXX_BOOL, logical);
++#else
++/// but is not available on MSMPI
++BOOST_MPI_DATATYPE(bool, MPI_C_BOOL, logical);
++#endif
+ 
+ /// INTERNAL ONLY
+ BOOST_MPI_DATATYPE(short, MPI_SHORT, integer);
+-- 
+2.43.0
+


### PR DESCRIPTION
Backport of #244 