### PR TITLE
fix cmake config windows

### DIFF
--- a/recipe/fix-cmake-dll-paths.py
+++ b/recipe/fix-cmake-dll-paths.py
@@ -1,0 +1,66 @@
+"""Fix Boost CMake config files to use the correct bin/ location for DLLs on Windows.
+
+On Windows with conda, Boost DLLs are installed to Library/bin/ while the CMake
+config files reference them from Library/lib/ (using ${_BOOST_LIBDIR}). This script
+patches the CMake config files to:
+  1. Add _BOOST_BINDIR = lib/../bin in any file that defines _BOOST_LIBDIR
+     (the per-library *-config.cmake wrapper files)
+  2. Use _BOOST_BINDIR for .dll IMPORTED_LOCATION paths
+     (the variant config files, e.g. libboost_date_time-variant-shared.cmake,
+      which are included by the wrapper and share its variable scope via
+      CMake's include())
+"""
+import re
+import sys
+from pathlib import Path
+
+
+def patch_cmake_file(path):
+    """Patch a single cmake file to fix DLL paths. Returns True if file was modified."""
+    content = path.read_text(encoding="utf-8")
+    original = content
+
+    # Add _BOOST_BINDIR after any _BOOST_LIBDIR definition (if not already present).
+    # This applies to the per-library *-config.cmake wrapper files.
+    if "_BOOST_BINDIR" not in content and "_BOOST_LIBDIR" in content:
+        content = re.sub(
+            r"(get_filename_component\s*\(\s*_BOOST_LIBDIR\s[^)]+\)[^\n]*\n)",
+            r'\1get_filename_component(_BOOST_BINDIR "${_BOOST_LIBDIR}/../bin" ABSOLUTE)\n',
+            content,
+        )
+
+    # Replace ${_BOOST_LIBDIR}/boost_*.dll in IMPORTED_LOCATION lines.
+    # _BOOST_BINDIR is available in the included variant files because CMake's
+    # include() shares the caller's variable scope.
+    content = re.sub(
+        r'\$\{_BOOST_LIBDIR\}/(boost_[^"\s)]+\.dll)',
+        r"${_BOOST_BINDIR}/\1",
+        content,
+    )
+
+    if content != original:
+        path.write_text(content, encoding="utf-8")
+        return True
+    return False
+
+
+def main(cmake_dir):
+    cmake_dir = Path(cmake_dir)
+    if not cmake_dir.is_dir():
+        print(f"Directory not found: {cmake_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    patched = 0
+    for cmake_file in sorted(cmake_dir.rglob("*.cmake")):
+        if patch_cmake_file(cmake_file):
+            patched += 1
+            print(f"  patched: {cmake_file.name}")
+
+    print(f"Patched {patched} cmake file(s) in {cmake_dir}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <cmake_dir>", file=sys.stderr)
+        sys.exit(1)
+    main(sys.argv[1])

--- a/recipe/install-lib.bat
+++ b/recipe/install-lib.bat
@@ -15,6 +15,6 @@ if [%PKG_NAME%] == [libboost-headers] (
     REM everything else
     xcopy /E /Y temp_prefix\lib %LIBRARY_LIB%
     REM Patch CMake configs so IMPORTED_LOCATION for DLLs points to bin/ not lib/
-    python "%RECIPE_DIR%\fix-cmake-dll-paths.py" %LIBRARY_LIB%\cmake
-    if %ERRORLEVEL% neq 0 exit 1
+    python "%RECIPE_DIR%\fix-cmake-dll-paths.py" "%LIBRARY_LIB%\cmake"
+    if errorlevel 1 exit /b 1
 )

--- a/recipe/install-lib.bat
+++ b/recipe/install-lib.bat
@@ -14,4 +14,7 @@ if [%PKG_NAME%] == [libboost-headers] (
 ) else (
     REM everything else
     xcopy /E /Y temp_prefix\lib %LIBRARY_LIB%
+    REM Patch CMake configs so IMPORTED_LOCATION for DLLs points to bin/ not lib/
+    python "%RECIPE_DIR%\fix-cmake-dll-paths.py" %LIBRARY_LIB%\cmake
+    if %ERRORLEVEL% neq 0 exit 1
 )

--- a/recipe/install-py.bat
+++ b/recipe/install-py.bat
@@ -2,3 +2,6 @@
 
 :: see build-py.bat
 xcopy /E /Y %SRC_DIR%\cf_%PY_VER%_%python_impl%_cmake %LIBRARY_LIB%\cmake
+:: Patch CMake configs so IMPORTED_LOCATION for DLLs points to bin/ not lib/
+python "%RECIPE_DIR%\fix-cmake-dll-paths.py" %LIBRARY_LIB%\cmake
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - patches/0001-Add-default-value-for-cxx-and-cxxflags-options-for-t.patch
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
Fix Boost CMake IMPORTED_LOCATION for DLLs on Windows (bin/ vs lib/). Fixes #250 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
