### PR TITLE
Make libboost-headers noarch on main

### DIFF
--- a/.ci_support/migrations/icu78.yaml
+++ b/.ci_support/migrations/icu78.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for icu 78
-  kind: version
-  migration_number: 1
-icu:
-- '78'
-migrator_ts: 1766302854.3781085

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -16,4 +16,7 @@ provider:
   linux_aarch64: default
   linux_ppc64le: default
   win: azure
+noarch_platforms:
+  - linux_64
+  - win_64
 test: native_and_emulated

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - patches/0001-Add-default-value-for-cxx-and-cxxflags-options-for-t.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -46,11 +46,16 @@ outputs:
   - name: libboost-headers
     script: install-lib.sh  # [unix]
     script: install-lib.bat  # [win]
+    build:
+      noarch: generic
     requirements:
       # dummy build env to avoid EnvironmentLocationNotFound on win
       build:   # [win]
         - cmake             # [win]
       host:
+      run:
+        - __unix  # [unix]
+        - __win   # [win]
       run_constrained:
         # avoid co-installation with old naming of package
         - boost-cpp <0.0a0


### PR DESCRIPTION
Matches #269 on `main` for Boost 1.92.x.

- makes `libboost-headers` noarch
- preserves Unix/Windows constraints with `__unix` and `__win`